### PR TITLE
Fix ODR violations in mazeGen.h, mazeSolve.h

### DIFF
--- a/include/mazeGen.h
+++ b/include/mazeGen.h
@@ -27,7 +27,7 @@
 
 using namespace std;
 
-int delayGen = 0; // delay in milliseconds
+static int delayGen = 0; // delay in milliseconds
 
 void RandomDFS(Maze &, int);
 void DFSGen(Maze &, int);

--- a/include/mazeSolve.h
+++ b/include/mazeSolve.h
@@ -35,7 +35,7 @@
 using namespace std;
 using namespace boost::heap;
 
-int delaySolve = 0;
+static int delaySolve = 0;
 
 void drawPath(Maze &, int);
 


### PR DESCRIPTION
With gcc 13.2.1 the current sources do not compile because of the definition of non-static variables at namespace scope. Making them static fixes it.

```
~/R/aMAZEd (master=) cmake --build build
[ 12%] Building CXX object CMakeFiles/Lib.dir/src/maze.cpp.o [ 25%] Building CXX object CMakeFiles/Lib.dir/src/draw.cpp.o [ 37%] Building CXX object CMakeFiles/Lib.dir/src/mazeGen.cpp.o [ 50%] Building CXX object CMakeFiles/Lib.dir/src/mazeSolve.cpp.o [ 62%] Building CXX object CMakeFiles/Lib.dir/src/vertex.cpp.o [ 75%] Linking CXX static library libLib.a
[ 75%] Built target Lib
[ 87%] Building CXX object CMakeFiles/exe.dir/src/main.cpp.o [100%] Linking CXX executable exe
/usr/bin/ld: libLib.a(mazeGen.cpp.o):(.bss+0x0): multiple definition of `delayGen'; CMakeFiles/exe.dir/src/main.cpp.o:(.bss+0x0): first defined here /usr/bin/ld: libLib.a(mazeSolve.cpp.o):(.bss+0x0): multiple definition of `delaySolve'; CMakeFiles/exe.dir/src/main.cpp.o:(.bss+0x4): first defined here collect2: error: ld returned 1 exit status
```